### PR TITLE
Fix the Heatmap overflowing on some devices

### DIFF
--- a/MoeMemos/Views/Heatmap.swift
+++ b/MoeMemos/Views/Heatmap.swift
@@ -13,6 +13,7 @@ fileprivate let defaultRows = [GridItem](repeating: GridItem(.flexible(minimum: 
 struct Heatmap: View {
     let rows = defaultRows
     let matrix: [DailyUsageStat]
+    let alignment: HorizontalAlignment
     
     var body: some View {
         GeometryReader { geometry in
@@ -21,16 +22,26 @@ struct Heatmap: View {
                     HeatmapStat(day: day)
                 }
             }
+            .frame(maxWidth: .infinity, alignment: frameAlignment)
+        }
+    }
+    
+    private var frameAlignment: Alignment {
+        switch alignment {
+        case .center: return .center
+        case .leading: return .leading
+        case .trailing: return .trailing
+        default: return .center
         }
     }
         
     private func count(in size: CGSize) -> Int {
-        let cellHeight = size.height / CGFloat(daysInWeek)
+        let cellHeight = (size.height + gridSpacing) / CGFloat(daysInWeek)
         if cellHeight <= 0 {
             return 0
         }
         let cellWidth = cellHeight
-        let columns = Int(floor(size.width / cellWidth))
+        let columns = Int(floor((size.width + gridSpacing) / cellWidth))
         let fullCells = Int(columns) * daysInWeek
         
         let today = Calendar.current.startOfDay(for: .now)
@@ -45,6 +56,6 @@ struct Heatmap: View {
 
 struct HeatMap_Previews: PreviewProvider {
     static var previews: some View {
-        Heatmap(matrix: DailyUsageStat.initialMatrix)
+        Heatmap(matrix: DailyUsageStat.initialMatrix, alignment: .center)
     }
 }

--- a/MoeMemos/Views/Sidebar.swift
+++ b/MoeMemos/Views/Sidebar.swift
@@ -32,7 +32,7 @@ struct Sidebar: View {
                         Text(weekDaySymbols.last ?? "")
                             .font(.footnote).foregroundStyle(.secondary)
                     }
-                    Heatmap(matrix: memosViewModel.matrix)
+                    Heatmap(matrix: memosViewModel.matrix, alignment: .trailing)
                 }
                 .frame(minHeight: 120, maxHeight: 120)
                 .padding(.bottom, 10)

--- a/MoeMemosWidgets/MemosGraphWidget.swift
+++ b/MoeMemosWidgets/MemosGraphWidget.swift
@@ -62,7 +62,7 @@ struct MemosGraphEntryView : View {
     var entry: Provider.Entry
 
     var body: some View {
-        Heatmap(matrix: entry.matrix ?? DailyUsageStat.initialMatrix)
+        Heatmap(matrix: entry.matrix ?? DailyUsageStat.initialMatrix, alignment: .center)
             .padding()
     }
 }


### PR DESCRIPTION
The Heatmap in sidebar overflows on some devices (i.e. iPhone 14):
![image](https://github.com/mudkipme/MoeMemos/assets/17932593/9323ff19-d422-410d-a43d-91c2d67b5aa7)

The calculation of columns is incorrect, the spacing of grids is ignored.

This pr fixes the calculation and changes the alignment of heatmap, it's aligned to trailing edge in sidebar and to center in widget now:
![image](https://github.com/mudkipme/MoeMemos/assets/17932593/0de1ee5a-72c9-4f1a-8fe6-da90ce05dfcd)
![image](https://github.com/mudkipme/MoeMemos/assets/17932593/00351944-f036-49e6-94a7-993a42513655)

*(The borders are for indicating and not included in this pr)*