### PR TITLE
feat: allow memo delete

### DIFF
--- a/MoeMemos/ViewModel/MemosViewModel.swift
+++ b/MoeMemos/ViewModel/MemosViewModel.swift
@@ -97,4 +97,11 @@ class MemosViewModel: ObservableObject {
             tag.name == name
         }
     }
+
+    func deleteMemo(id: Int) async throws {
+        _ = try await memos.deleteMemo(id: id)
+        memoList = memoList.filter({ memo in
+            memo.id != id
+        })
+    }
 }

--- a/MoeMemos/Views/MemoCard.swift
+++ b/MoeMemos/Views/MemoCard.swift
@@ -16,6 +16,7 @@ struct MemoCard: View {
     @EnvironmentObject private var memosViewModel: MemosViewModel
     @State private var showingEdit = false
     @State private var showingLegacyShareSheet = false
+    @State private var showingDeleteConfirmation = false
     
     init(_ memo: Memo, defaultMemoVisibility: MemosVisibility) {
         self.memo = memo
@@ -62,6 +63,14 @@ struct MemoCard: View {
         .sheet(isPresented: $showingEdit) {
             MemoInput(memo: memo)
         }
+        .confirmationDialog("memo.delete.confirm", isPresented: $showingDeleteConfirmation, titleVisibility: .visible) {
+            Button("memo.action.ok", role: .destructive) {
+                Task {
+                    try await memosViewModel.deleteMemo(id: memo.id)
+                }
+            }
+            Button("memo.action.cancel", role: .cancel) {}
+        }
     }
     
     @ViewBuilder
@@ -107,6 +116,11 @@ struct MemoCard: View {
             }
         }, label: {
             Label("memo.archive", systemImage: "archivebox")
+        })
+        Button(role: .destructive, action: {
+            showingDeleteConfirmation = true
+        }, label: {
+            Label("memo.delete", systemImage: "trash")
         })
     }
     


### PR DESCRIPTION
Allows memos to be deleted directly from the primary memo view (which previously only allowed archiving). Replicated the code from the archive list which did allow deleting memos.