### PR TITLE
feat(widget): add pinned memory widget with selectable memo

### DIFF
--- a/MoeMemos/MoeMemosApp.swift
+++ b/MoeMemos/MoeMemosApp.swift
@@ -61,7 +61,7 @@ struct MoeMemosApp: App {
                         guard
                             let encodedIdentifier,
                             !encodedIdentifier.isEmpty,
-                            let persistentIdentifier = decodePersistentIdentifier(from: encodedIdentifier)
+                            let persistentIdentifier = PersistentIdentifierTokenCoder.decode(encodedIdentifier)
                         else {
                             return
                         }
@@ -69,12 +69,5 @@ struct MoeMemosApp: App {
                     }
                 }
         }
-    }
-
-    private func decodePersistentIdentifier(from encodedIdentifier: String) -> PersistentIdentifier? {
-        guard let data = Data(base64Encoded: encodedIdentifier) else {
-            return nil
-        }
-        return try? JSONDecoder().decode(PersistentIdentifier.self, from: data)
     }
 }

--- a/MoeMemos/Resources/Localization/de.lproj/Localizable.strings
+++ b/MoeMemos/Resources/Localization/de.lproj/Localizable.strings
@@ -71,6 +71,8 @@
 "widget.memories.description" = "Erinnere dich an deine früheren Memos";
 "widget.memo-graph" = "Memos Diagramm";
 "widget.memo-graph.description" = "Das Diagramm, das anzeigt, wie viele Memos du in den letzten Wochen täglich verfasst hasts.";
+"widget.pinned-memory" = "Angeheftete Erinnerung";
+"widget.pinned-memory.description" = "Zeigt ein ausgewähltes Memo im Widget an.";
 
 "share.memo-saved" = "Memo gespeichert.";
 

--- a/MoeMemos/Resources/Localization/en.lproj/Localizable.strings
+++ b/MoeMemos/Resources/Localization/en.lproj/Localizable.strings
@@ -71,6 +71,8 @@
 "widget.memories.description" = "Remember your past memos.";
 "widget.memo-graph" = "Memos Graph";
 "widget.memo-graph.description" = "The graph to display how much memos you composed every day in recent weeks.";
+"widget.pinned-memory" = "Pinned Memory";
+"widget.pinned-memory.description" = "Display one selected memo in the widget.";
 
 "share.memo-saved" = "Memo saved.";
 

--- a/MoeMemos/Resources/Localization/fr.lproj/Localizable.strings
+++ b/MoeMemos/Resources/Localization/fr.lproj/Localizable.strings
@@ -73,6 +73,8 @@
 "widget.memories.description" = "Souvenez-vous de vos anciens memos.";
 "widget.memo-graph" = "Graphique des memos";
 "widget.memo-graph.description" = "Le graphique affiche le nombre de memos que vous avez rédigés chaque jour au cours des dernières semaines.";
+"widget.pinned-memory" = "Memo épinglé";
+"widget.pinned-memory.description" = "Affiche un memo sélectionné dans le widget.";
 
 "share.memo-saved" = "Memo sauvegardé.";
 

--- a/MoeMemos/Resources/Localization/it.lproj/Localizable.strings
+++ b/MoeMemos/Resources/Localization/it.lproj/Localizable.strings
@@ -73,6 +73,8 @@
 "widget.memories.description" = "Ricorda i tuoi vecchi memos.";
 "widget.memo-graph" = "Grafico promemoria";
 "widget.memo-graph.description" = "Il grafico mostra il numero di promemoria scritti ogni giorno nelle ultime settimane.";
+"widget.pinned-memory" = "Memo fissato";
+"widget.pinned-memory.description" = "Mostra un memo selezionato nel widget.";
  
 "share.memo-saved" = "Promemoria salvato.";
  

--- a/MoeMemos/Resources/Localization/ja.lproj/Localizable.strings
+++ b/MoeMemos/Resources/Localization/ja.lproj/Localizable.strings
@@ -71,6 +71,8 @@
 "widget.memories.description" = "過去のメモを記憶します。";
 "widget.memo-graph" = "メモグラフ";
 "widget.memo-graph.description" = "最近数週間に毎日作成したメモの量を表示するグラフ。";
+"widget.pinned-memory" = "固定メモ";
+"widget.pinned-memory.description" = "選択した1件のメモをウィジェットに表示します。";
 
 "share.memo-saved" = "保存したメモ。";
 

--- a/MoeMemos/Resources/Localization/ru.lproj/Localizable.strings
+++ b/MoeMemos/Resources/Localization/ru.lproj/Localizable.strings
@@ -71,6 +71,8 @@
 "widget.memories.description" = "Вспомните ваши прошлые заметки.";
 "widget.memo-graph" = "График Memos";
 "widget.memo-graph.description" = "График, показывающий количество созданных Memos за последние недели.";
+"widget.pinned-memory" = "Закреплённая заметка";
+"widget.pinned-memory.description" = "Показывает выбранную заметку в виджете.";
 
 "share.memo-saved" = "Memo сохранена.";
 

--- a/MoeMemos/Resources/Localization/zh-Hans.lproj/Localizable.strings
+++ b/MoeMemos/Resources/Localization/zh-Hans.lproj/Localizable.strings
@@ -71,6 +71,8 @@
 "widget.memories.description" = "回忆过去的 MEMO。";
 "widget.memo-graph" = "日记方格";
 "widget.memo-graph.description" = "用方格显示每天写下的 MEMO 数量。";
+"widget.pinned-memory" = "置顶回忆";
+"widget.pinned-memory.description" = "在小组件中显示你选择的一条 MEMO。";
 
 "share.memo-saved" = "已保存 MEMO";
 

--- a/MoeMemos/Resources/Localization/zh-Hant.lproj/Localizable.strings
+++ b/MoeMemos/Resources/Localization/zh-Hant.lproj/Localizable.strings
@@ -71,6 +71,8 @@
 "widget.memories.description" = "回憶過去的 MEMO。";
 "widget.memo-graph" = "日記方格";
 "widget.memo-graph.description" = "用方格顯示每天寫下的 MEMO 數量。";
+"widget.pinned-memory" = "置頂回憶";
+"widget.pinned-memory.description" = "在小工具中顯示你選擇的一則 MEMO。";
 
 "share.memo-saved" = "已儲存 MEMO";
 

--- a/MoeMemos/Views/MemoView.swift
+++ b/MoeMemos/Views/MemoView.swift
@@ -168,7 +168,7 @@ struct MemoView: View {
     }
 
     private var memo: StoredMemo? {
-        if let memo = memosViewModel.memoList.first(where: { $0.id == memoId }) {
+        if let memo = memosViewModel.memoList.first(where: { $0.id == memoId && !$0.softDeleted }) {
             return memo
         }
         return (try? memosViewModel.service)?.memo(id: memoId)

--- a/MoeMemosWidgets/MemoryWidgetConfiguration.swift
+++ b/MoeMemosWidgets/MemoryWidgetConfiguration.swift
@@ -7,6 +7,8 @@
 
 import Foundation
 import AppIntents
+import Models
+import Account
 
 @available(iOS 17.0, macOS 14.0, watchOS 10.0, *)
 struct MemoryWidgetConfiguration: AppIntent, WidgetConfigurationIntent, CustomIntentMigratedAppIntent {
@@ -28,6 +30,95 @@ struct MemoryWidgetConfiguration: AppIntent, WidgetConfigurationIntent, CustomIn
     }
 }
 
+@available(iOS 17.0, macOS 14.0, watchOS 10.0, *)
+struct PinnedMemoryWidgetConfiguration: AppIntent, WidgetConfigurationIntent {
+    static let title: LocalizedStringResource = "Pinned Memory Widget Configuration"
+    static let description = IntentDescription("Select one memo to keep showing in this widget")
+
+    @Parameter(title: "Update")
+    var frequency: MemoryUpdatePeriodAppEnum?
+
+    @Parameter(title: "Memo")
+    var memo: MemoryWidgetMemoEntity?
+
+    static var parameterSummary: some ParameterSummary {
+        Summary()
+    }
+
+    func perform() async throws -> some IntentResult {
+        return .result()
+    }
+}
+
+@available(iOS 17.0, macOS 14.0, watchOS 10.0, *)
+struct MemoryWidgetMemoEntity: AppEntity, Identifiable, Sendable {
+    static let typeDisplayRepresentation: TypeDisplayRepresentation = "Memo"
+    static let defaultQuery = MemoryWidgetMemoEntityQuery()
+
+    let id: String
+    let content: String
+    let createdAt: Date
+
+    var displayRepresentation: DisplayRepresentation {
+        let title = content
+            .replacingOccurrences(of: "\n", with: " ")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        return DisplayRepresentation(title: "\(title.prefix(50))")
+    }
+}
+
+@available(iOS 17.0, macOS 14.0, watchOS 10.0, *)
+struct MemoryWidgetMemoEntityQuery: EntityQuery {
+    func entities(for identifiers: [MemoryWidgetMemoEntity.ID]) async throws -> [MemoryWidgetMemoEntity] {
+        await MainActor.run {
+            let service = AccountManager(modelContext: AppInfo().modelContext).currentService
+            guard let service else { return [] }
+
+            return identifiers.compactMap { id in
+                guard
+                    let persistentId = PersistentIdentifierTokenCoder.decode(id),
+                    let memo = service.memo(id: persistentId)
+                else {
+                    return nil
+                }
+
+                return MemoryWidgetMemoEntity(
+                    id: id,
+                    content: memo.content,
+                    createdAt: memo.createdAt
+                )
+            }
+        }
+    }
+
+    func suggestedEntities() async throws -> [MemoryWidgetMemoEntity] {
+        try await loadSuggestedEntitiesFromStore()
+    }
+
+    func defaultResult() async -> MemoryWidgetMemoEntity? {
+        return try? await suggestedEntities().first
+    }
+}
+
+@MainActor
+private func loadSuggestedEntitiesFromStore() async throws -> [MemoryWidgetMemoEntity] {
+    let service = AccountManager(modelContext: AppInfo().modelContext).currentService
+    guard let service else { return [] }
+
+    let memos = try await service.listMemos()
+    return memos.prefix(100).compactMap { memo in
+        guard let token = PersistentIdentifierTokenCoder.encode(memo.id) else {
+            return nil
+        }
+
+        return MemoryWidgetMemoEntity(
+            id: token,
+            content: memo.content,
+            createdAt: memo.createdAt
+        )
+    }
+}
+
 @available(iOS 16.0, macOS 13.0, watchOS 9.0, tvOS 16.0, *)
 fileprivate extension IntentDialog {
     static func frequencyParameterDisambiguationIntro(count: Int, frequency: MemoryUpdatePeriodAppEnum) -> Self {
@@ -37,4 +128,3 @@ fileprivate extension IntentDialog {
         "Just to confirm, you wanted ‘\(frequency)’?"
     }
 }
-

--- a/MoeMemosWidgets/MoeMemosWidgetsBundle.swift
+++ b/MoeMemosWidgets/MoeMemosWidgetsBundle.swift
@@ -13,6 +13,7 @@ struct MoeMemosWidgetsBundle: WidgetBundle {
     var body: some Widget {
         MemosGraphWidget()
         MemoryWidget()
+        PinnedMemoryWidget()
         if #available(iOS 18.0, *) {
             QuickMemoWidget()
         }

--- a/Packages/Account/Sources/Account/LocalService.swift
+++ b/Packages/Account/Sources/Account/LocalService.swift
@@ -31,7 +31,10 @@ final class LocalService: Service {
     }
 
     func memo(id: PersistentIdentifier) -> StoredMemo? {
-        store.fetchMemo(id: id)
+        guard let memo = store.fetchMemo(id: id), !memo.softDeleted else {
+            return nil
+        }
+        return memo
     }
 
     func createMemo(content: String, visibility: MemoVisibility?, resources: [PersistentIdentifier], tags: [String]?) async throws -> StoredMemo {

--- a/Packages/Account/Sources/Account/SyncingRemoteService.swift
+++ b/Packages/Account/Sources/Account/SyncingRemoteService.swift
@@ -61,7 +61,10 @@ final class SyncingRemoteService: Service, SyncableService, PendingOperationsSer
     }
 
     func memo(id: PersistentIdentifier) -> StoredMemo? {
-        store.fetchMemo(id: id)
+        guard let memo = store.fetchMemo(id: id), !memo.softDeleted else {
+            return nil
+        }
+        return memo
     }
 
     func createMemo(content: String, visibility: MemoVisibility?, resources: [PersistentIdentifier], tags: [String]?) async throws -> StoredMemo {

--- a/Packages/Models/Sources/Models/PersistentIdentifierTokenCoder.swift
+++ b/Packages/Models/Sources/Models/PersistentIdentifierTokenCoder.swift
@@ -1,0 +1,25 @@
+//
+//  PersistentIdentifierTokenCoder.swift
+//
+//
+//  Created by Codex on 2026/2/26.
+//
+
+import Foundation
+import SwiftData
+
+public enum PersistentIdentifierTokenCoder {
+    public static func encode(_ identifier: some Encodable) -> String? {
+        guard let encoded = try? JSONEncoder().encode(identifier) else {
+            return nil
+        }
+        return encoded.base64EncodedString()
+    }
+
+    public static func decode(_ token: String) -> PersistentIdentifier? {
+        guard let data = Data(base64Encoded: token) else {
+            return nil
+        }
+        return try? JSONDecoder().decode(PersistentIdentifier.self, from: data)
+    }
+}


### PR DESCRIPTION
## Summary
This PR adds a new pinned memory widget that lets users choose one specific memo to display. This addresses the need to keep one important memo always visible, instead of showing only random memories.

## Changes
- Add `PinnedMemoryWidget` and register it in `MoeMemosWidgetsBundle`.
- Add `PinnedMemoryWidgetConfiguration` with:
  - update frequency (`MemoryUpdatePeriodAppEnum`)
  - selectable memo parameter (`MemoryWidgetMemoEntity`)
- Reuse the existing memory card UI by introducing a shared `MemoryCardView` for both memory widgets.
- Add `PersistentIdentifierTokenCoder` in `Models` and use it for widget deep link token encode/decode.
- Update app deep link handling to use the shared token decoder.
- Filter soft-deleted memos when resolving `memo(id:)` in both local and syncing services.
- Add localization entries for:
  - `widget.pinned-memory`
  - `widget.pinned-memory.description`

## Notes
- Tested on iOS Simulator:
  - pinned widget selection works
  - widget display and deep link behavior works as expected
