### PR TITLE
new: video attachment preview first frame

### DIFF
--- a/MoeMemos/Views/MemoCardContent.swift
+++ b/MoeMemos/Views/MemoCardContent.swift
@@ -84,12 +84,7 @@ struct MemoCardContent: View {
             }
             
             ForEach(resources()) { content in
-                if case let .images(urls) = content {
-                    MemoCardImageView(images: urls)
-                }
-                if case let .attachment(resource) = content {
-                    Attachment(resource: resource)
-                }
+                resourceView(for: content)
             }
         }
         .onChange(of: memo.content) { _, newContent in
@@ -103,14 +98,24 @@ struct MemoCardContent: View {
         }
     }
     
+    @ViewBuilder
+    private func resourceView(for content: MemoResource) -> some View {
+        switch content {
+        case .images(let urls):
+            MemoCardImageView(media: urls)
+        case .attachment(let resource):
+            Attachment(resource: resource)
+        }
+    }
+
     private func resources() -> [MemoResource] {
         var attachments = [MemoResource]()
         let resourceList = memo.attachments
         let imageResources = resourceList.filter { resource in
-            resource.mimeType.hasPrefix("image/") == true
+            resource.mimeType.hasPrefix("image/") == true || resource.mimeType.hasPrefix("video/") == true
         }
         let otherResources = resourceList.filter { resource in
-            !(resource.mimeType.hasPrefix("image/") == true)
+            !(resource.mimeType.hasPrefix("image/") == true) && !(resource.mimeType.hasPrefix("video/") == true)
         }
         
         if !imageResources.isEmpty {

--- a/MoeMemos/Views/MemoCardImageView.swift
+++ b/MoeMemos/Views/MemoCardImageView.swift
@@ -12,7 +12,7 @@ import MemoKit
 import DesignSystem
 
 struct MemoCardImageView: View {
-    let images: [any ResourcePresentable]
+    let media: [any ResourcePresentable]
 
     @State private var imagePreviewURL: URL?
     @Environment(AccountManager.self) private var memosManager: AccountManager
@@ -72,6 +72,16 @@ struct MemoCardImageView: View {
     }
 
     @ViewBuilder
+    private func getAsyncImage(resource: any ResourcePresentable, key: String) -> some View {
+        if resource.mimeType.hasPrefix("video/") {
+            asyncVideoThumbnailImage(resource: resource, key: key)
+        } else if resource.mimeType.hasPrefix("image/") {
+            asyncImage(resource: resource, key: key)
+        } else {
+            EmptyView()
+        }
+    }
+    
     private func asyncImage(resource: any ResourcePresentable, key: String) -> some View {
         AsyncImage(url: displayURL(for: resource, key: key)) { image in
             image
@@ -86,7 +96,14 @@ struct MemoCardImageView: View {
             await resolveLocalFileIfNeeded(for: resource, key: key)
         }
     }
-
+    
+    private func asyncVideoThumbnailImage(resource: any ResourcePresentable, key: String) -> some View {
+        AsyncThumbnailImage(videoURL: displayURL(for: resource, key: key))
+            .task {
+                await resolveLocalFileIfNeeded(for: resource, key: key)
+            }
+    }
+    
     private func handleTap(resource: any ResourcePresentable, key: String) {
         if let local = localURL(for: resource, key: key) {
             imagePreviewURL = local
@@ -123,7 +140,7 @@ struct MemoCardImageView: View {
         //
         // Please submit a pull request if you have a better solution
         Color(white: 1, opacity: 0.00001).overlay {
-            asyncImage(resource: resource, key: key)
+            getAsyncImage(resource: resource, key: key)
         }
         .aspectRatio(aspectRatio, contentMode: contentMode)
         .frame(maxWidth: .infinity)
@@ -138,25 +155,25 @@ struct MemoCardImageView: View {
     private var content: some View {
         if horizontalSizeClass == .regular {
             LazyVGrid(columns: [GridItem(.adaptive(minimum: 150, maximum: 200), spacing: 5)], spacing: 5) {
-                ForEach(Array(images.enumerated()), id: \.offset) { index, resource in
+                ForEach(Array(media.enumerated()), id: \.offset) { index, resource in
                     imageItem(resource: resource, key: key(for: resource, index: index), aspectRatio: 1.0, contentMode: .fill)
                 }
             }
         } else {
-            switch images.count {
+            switch media.count {
             case 1:
-                imageItem(resource: images[0], key: key(for: images[0], index: 0), aspectRatio: 16.0 / 9.0, contentMode: .fit)
+                imageItem(resource: media[0], key: key(for: media[0], index: 0), aspectRatio: 16.0 / 9.0, contentMode: .fit)
             case 2...3:
                 HStack(spacing: 5) {
-                    ForEach(Array(images.enumerated()), id: \.offset) { index, resource in
+                    ForEach(Array(media.enumerated()), id: \.offset) { index, resource in
                         imageItem(resource: resource, key: key(for: resource, index: index), aspectRatio: 1.0, contentMode: .fill)
                     }
                 }
                 .aspectRatio(contentMode: .fit)
                 .frame(maxWidth: .infinity)
             default:
-                LazyVGrid(columns: [GridItem(.adaptive(minimum: images.count == 4 ? 120 : 90, maximum: 150), spacing: 5)], spacing: 5) {
-                    ForEach(Array(images.enumerated()), id: \.offset) { index, resource in
+                LazyVGrid(columns: [GridItem(.adaptive(minimum: media.count == 4 ? 120 : 90, maximum: 150), spacing: 5)], spacing: 5) {
+                    ForEach(Array(media.enumerated()), id: \.offset) { index, resource in
                         imageItem(resource: resource, key: key(for: resource, index: index), aspectRatio: 1.0, contentMode: .fill)
                     }
                 }

--- a/MoeMemos/Views/Resources.swift
+++ b/MoeMemos/Views/Resources.swift
@@ -23,12 +23,12 @@ struct Resources: View {
     @State private var viewModel = ResourceListViewModel()
     @State private var section: ResourceSection = .image
 
-    private var imageResources: [StoredResource] {
-        viewModel.resourceList.filter { $0.mimeType.hasPrefix("image/") }
+    private var mediaResources: [StoredResource] {
+        viewModel.resourceList.filter { $0.mimeType.hasPrefix("image/") || $0.mimeType.hasPrefix("video/") }
     }
 
     private var otherResources: [StoredResource] {
-        viewModel.resourceList.filter { !$0.mimeType.hasPrefix("image/") }
+        viewModel.resourceList.filter { !$0.mimeType.hasPrefix("image/") && !$0.mimeType.hasPrefix("video/") }
     }
 
     var body: some View {
@@ -42,12 +42,12 @@ struct Resources: View {
             .padding()
 
             if section == .image {
-                if imageResources.isEmpty {
+                if mediaResources.isEmpty {
                     ContentUnavailableView("resources.empty.images", systemImage: "photo.on.rectangle")
                 } else {
                     ScrollView {
                         LazyVGrid(columns: columns) {
-                            ForEach(imageResources) { item in
+                            ForEach(mediaResources) { item in
                                 ResourceCard(resource: item, resourceManager: viewModel)
                             }
                         }

--- a/Packages/MemoKit/Sources/MemoKit/Components/AsyncThumbnailImage.swift
+++ b/Packages/MemoKit/Sources/MemoKit/Components/AsyncThumbnailImage.swift
@@ -1,0 +1,92 @@
+//
+//  AsyncThumbnailImage.swift
+//  MoeMemos
+//
+//  Created by Bexon Pak on 12.03.26.
+//
+
+import SwiftUI
+import AVFoundation
+
+public struct AsyncThumbnailImage: View {
+    let videoURL: URL?
+    @State private var thumbnail: UIImage?
+    @State private var isLoading = false
+    
+    public init(videoURL: URL?, thumbnail: UIImage? = nil, isLoading: Bool = false) {
+        self.videoURL = videoURL
+        self.thumbnail = thumbnail
+        self.isLoading = isLoading
+    }
+    
+    public var body: some View {
+        Group {
+            if thumbnail != nil {
+                ZStack(alignment: .center) {
+                    thumbnailLayer
+                    playButton
+                }
+            } else if isLoading {
+                ProgressView()
+            } else {
+                Color.gray
+            }
+        }
+        .onAppear {
+            Task {
+                await loadThumbnail()
+            }
+        }
+    }
+    
+    @ViewBuilder
+    private var thumbnailLayer: some View {
+        if let thumbnail = thumbnail {
+            Image(uiImage: thumbnail)
+                .resizable()
+                .aspectRatio(contentMode: .fill)
+        } else if isLoading {
+            ProgressView()
+        } else {
+            Color.gray.opacity(0.3)
+        }
+    }
+    
+    @ViewBuilder
+    private var playButton: some View {
+        if #available(iOS 26.0, *) {
+            Image(systemName: "play.fill")
+                .font(.system(size: 24))
+                .frame(width: 24, height: 24)
+                .foregroundStyle(.black)
+                .padding(14)
+                .symbolRenderingMode(.hierarchical)
+                .glassEffect(.clear)
+                .opacity(thumbnail != nil ? 1 : 0)
+                .animation(.easeInOut(duration: 0.2), value: thumbnail)
+        } else {
+            Image(systemName: "play.fill")
+                .font(.system(size: 24))
+                .frame(width: 24, height: 24)
+                .foregroundStyle(.black)
+                .padding(14)
+                .symbolRenderingMode(.hierarchical)
+                .background(Circle().fill(.ultraThinMaterial))
+                .opacity(thumbnail != nil ? 1 : 0)
+                .animation(.easeInOut(duration: 0.2), value: thumbnail)
+        }
+    }
+    
+    private func loadThumbnail() async {
+        guard thumbnail == nil, !isLoading else { return }
+        isLoading = true
+        
+        do {
+            let image = try await VideoThumbnailGenerator.generateThumbnail(from: videoURL)
+            self.thumbnail = image
+        } catch {
+            print(error)
+        }
+        self.isLoading = false
+    }
+}

--- a/Packages/MemoKit/Sources/MemoKit/Components/ResourceCard.swift
+++ b/Packages/MemoKit/Sources/MemoKit/Components/ResourceCard.swift
@@ -22,13 +22,7 @@ public struct ResourceCard: View {
             .aspectRatio(1, contentMode: .fit)
             .overlay {
                 if let downloadedURL = downloadedURL {
-                    AsyncImage(url: downloadedURL) { image in
-                        image
-                            .resizable()
-                            .scaledToFill()
-                    } placeholder: {
-                        ProgressView()
-                    }
+                    getAsyncImage(downloadedURL)
                 }
             }
             .clipShape(RoundedRectangle(cornerRadius: 8))
@@ -57,6 +51,31 @@ public struct ResourceCard: View {
                     .edgesIgnoringSafeArea(.bottom)
                     .background(TransparentBackground())
             }
+    }
+    
+    @ViewBuilder
+    private func getAsyncImage(_ downloadedURL: URL) -> some View {
+        if resource.mimeType.hasPrefix("video/") {
+            asyncVideoThumbnailImage(downloadedURL)
+        } else if resource.mimeType.hasPrefix("image/") {
+            asyncImage(downloadedURL)
+        } else {
+            EmptyView()
+        }
+    }
+    
+    private func asyncImage(_ downloadedURL: URL) -> some View {
+        AsyncImage(url: downloadedURL) { image in
+            image
+                .resizable()
+                .scaledToFill()
+        } placeholder: {
+            ProgressView()
+        }
+    }
+    
+    private func asyncVideoThumbnailImage(_ downloadedURL: URL) -> some View {
+        AsyncThumbnailImage(videoURL: downloadedURL)
     }
 
     @ViewBuilder

--- a/Packages/MemoKit/Sources/MemoKit/Editor/Components/MemoEditorResourceView.swift
+++ b/Packages/MemoKit/Sources/MemoKit/Editor/Components/MemoEditorResourceView.swift
@@ -5,15 +5,19 @@ struct MemoEditorResourceView: View {
     var viewModel: MemoEditorViewModel
 
     var body: some View {
-        let imageResources = viewModel.resourceList.filter { $0.mimeType.hasPrefix("image/") == true }
-        let attachmentResources = viewModel.resourceList.filter { $0.mimeType.hasPrefix("image/") == false }
+        let mediaResources = viewModel.resourceList.filter {
+            $0.mimeType.hasPrefix("image/") == true || $0.mimeType.hasPrefix("video/") == true
+        }
+        let attachmentResources = viewModel.resourceList.filter {
+            $0.mimeType.hasPrefix("image/") == false && $0.mimeType.hasPrefix("video/") == false
+        }
 
         if !viewModel.resourceList.isEmpty {
             VStack(alignment: .leading, spacing: 8) {
-                if !imageResources.isEmpty {
+                if !mediaResources.isEmpty {
                     ScrollView(.horizontal, showsIndicators: false) {
                         LazyHStack {
-                            ForEach(imageResources, id: \.id) { item in
+                            ForEach(mediaResources, id: \.id) { item in
                                 ResourceCard(resource: item, resourceManager: viewModel)
                             }
                         }

--- a/Packages/MemoKit/Sources/MemoKit/Helpers/VideoThumbnailGenerator.swift
+++ b/Packages/MemoKit/Sources/MemoKit/Helpers/VideoThumbnailGenerator.swift
@@ -1,0 +1,61 @@
+//
+//  VideoThumbnailGenerator.swift
+//  MoeMemos
+//
+//  Created by Bexon Pak on 12.03.26.
+//
+
+import AVFoundation
+import UIKit
+
+enum VideoThumbnailGenerator {
+    
+    /// Retrieve thumbnails from online video URLs (without downloading full videos)
+    /// - Parameters:
+    ///   - url: Video URL string
+    ///   - seconds: Capture time point (default: 0 seconds, i.e., first frame)
+    static func generateThumbnail(
+        from url: URL?,
+        at seconds: Double = 0
+    ) async throws -> UIImage {
+        guard let url else {
+            throw ThumbnailError.invalidURL
+        }
+        
+        let asset = AVURLAsset(url: url)
+        let imageGenerator = AVAssetImageGenerator(asset: asset)
+        
+        imageGenerator.appliesPreferredTrackTransform = true
+        
+        // Only request precise timestamps; do not generate intermediate frames.
+        imageGenerator.requestedTimeToleranceBefore = .zero
+        imageGenerator.requestedTimeToleranceAfter = .zero
+        
+        // Set maximum size (reduce memory usage)
+        imageGenerator.maximumSize = CGSize(width: 720, height: 720)
+        
+        let time = CMTime(seconds: seconds, preferredTimescale: 600)
+        
+        return try await withCheckedThrowingContinuation { continuation in
+            imageGenerator.generateCGImageAsynchronously(for: time) { cgImage, actualTime, error in
+                if let error = error {
+                    continuation.resume(throwing: error)
+                    return
+                }
+                
+                guard let cgImage = cgImage else {
+                    continuation.resume(throwing: ThumbnailError.generationFailed)
+                    return
+                }
+                
+                let thumbnail = UIImage(cgImage: cgImage)
+                continuation.resume(returning: thumbnail)
+            }
+        }
+    }
+    
+    enum ThumbnailError: Error {
+        case invalidURL
+        case generationFailed
+    }
+}


### PR DESCRIPTION
**Feel free to make any changes or reject this PR. :grinning:**

### ⛔️ What was the problem?

- Unable to preview videos.

### 🛠 What is the solution?

- Retrieve the first frame of videos for preview.
  - Because Memos does not generate thumbnails for videos.
  - Only get first frame, no need to wait for the full video to finish loading.

### 🧪 How was this tested?

- Video previews display correctly on the Editor, Memos, and Resources pages.

### 📸 Screenshots

| | Before | After  |
|---|---|---|
| Editor | ![tempImagexntWcI](https://github.com/user-attachments/assets/5b9261f8-2cfe-4fdb-9e08-fa75dc01259e) | ![tempImage5oxeY2](https://github.com/user-attachments/assets/cdc07287-dfae-4469-a1d8-1554333b2b97) | 
| Editor (Multiple) | ![tempImagebMjx5X](https://github.com/user-attachments/assets/dff62b06-d8bd-401b-80b7-c94b2e345d7a) | ![tempImagehmzxGD](https://github.com/user-attachments/assets/040f6b32-8a1f-4d67-bcd4-15ea2fc071b4) |
| Memos | ![tempImageEANu0H](https://github.com/user-attachments/assets/cf67861d-b29a-4eb8-a4f7-61fc1c1c7b13) | ![tempImageqxUZJL](https://github.com/user-attachments/assets/593596f0-efe2-4ca8-b0af-200318114f13) |
| Memos (Multiple) | ![tempImageILaGbC](https://github.com/user-attachments/assets/36841893-cc86-42de-8839-958f7de728c9) | ![tempImagervtSsT](https://github.com/user-attachments/assets/707cec7b-c386-46a2-a6e4-4f356ee7c1b6) |
| Resources | ![tempImage7b4MEZ](https://github.com/user-attachments/assets/c2ffd72a-32b4-4f64-b350-c70b47e23759) | ![tempImageK67WWb](https://github.com/user-attachments/assets/d954ddb4-e1bf-4489-839d-53ade0ed68d4) |