### PR TITLE
feat: allow admins to edit other admins' memos on the explore page

### DIFF
--- a/MoeMemos/ViewModel/ExploreViewModel.swift
+++ b/MoeMemos/ViewModel/ExploreViewModel.swift
@@ -52,4 +52,13 @@ import Factory
             throw error
         }
     }
+
+    @MainActor
+    func editMemo(remoteId: String, content: String, visibility: MemoVisibility) async throws {
+        var updated = try await service.updateMemo(remoteId: remoteId, content: content, resources: nil, visibility: visibility, tags: nil, pinned: nil, updatedAt: nil)
+        if let index = memoList.firstIndex(where: { $0.remoteId == remoteId }) {
+            updated.user = memoList[index].user
+            memoList[index] = updated
+        }
+    }
 }

--- a/MoeMemos/Views/Explore.swift
+++ b/MoeMemos/Views/Explore.swift
@@ -6,25 +6,31 @@
 //
 
 import SwiftUI
+import Account
 
 struct Explore: View {
     @State private var viewModel = ExploreViewModel()
+    @Environment(AccountViewModel.self) private var accountViewModel: AccountViewModel
 
     var body: some View {
+        let isAdmin = accountViewModel.currentUser?.isAdmin ?? false
+
         Group {
             if viewModel.memoList.isEmpty {
                 ContentUnavailableView("explore.empty", systemImage: "globe")
             } else {
                 List(viewModel.memoList, id: \.remoteId) { memo in
                     Section {
-                        ExploreMemoCard(memo: memo)
-                            .onAppear {
-                                Task {
-                                    if viewModel.memoList.firstIndex(where: { $0.remoteId == memo.remoteId }) == viewModel.memoList.count - 2 {
-                                        try await viewModel.loadMoreMemos()
-                                    }
+                        ExploreMemoCard(memo: memo, isAdmin: isAdmin) { remoteId, content, visibility in
+                            try await viewModel.editMemo(remoteId: remoteId, content: content, visibility: visibility)
+                        }
+                        .onAppear {
+                            Task {
+                                if viewModel.memoList.firstIndex(where: { $0.remoteId == memo.remoteId }) == viewModel.memoList.count - 2 {
+                                    try await viewModel.loadMoreMemos()
                                 }
                             }
+                        }
                     }
                 }
                 .listStyle(InsetGroupedListStyle())

--- a/MoeMemos/Views/ExploreMemoCard.swift
+++ b/MoeMemos/Views/ExploreMemoCard.swift
@@ -7,9 +7,14 @@
 
 import SwiftUI
 import Models
+import MemoKit
 
 struct ExploreMemoCard: View {
     let memo: Memo
+    let isAdmin: Bool
+    let onEdit: (_ remoteId: String, _ content: String, _ visibility: MemoVisibility) async throws -> Void
+
+    @State private var isEditingMemo = false
 
     var body: some View {
         VStack(alignment: .leading) {
@@ -17,17 +22,126 @@ struct ExploreMemoCard: View {
                 Text(memo.renderTime())
                     .font(.footnote)
                     .foregroundColor(.secondary)
-                
+
                 if let creatorName = memo.user?.nickname {
                     Text("@\(creatorName)")
                         .font(.footnote)
                         .foregroundColor(.secondary)
                 }
+
+                if isAdmin {
+                    Spacer()
+                    Menu {
+                        Button {
+                            isEditingMemo = true
+                        } label: {
+                            Label("memo.edit", systemImage: "pencil")
+                        }
+                        ShareLink(item: memo.content) {
+                            Label("memo.share", systemImage: "square.and.arrow.up")
+                        }
+                    } label: {
+                        Image(systemName: "ellipsis")
+                            .padding([.leading, .top, .bottom], 10)
+                    }
+                }
             }
             .padding(.vertical, 5)
-            
-            MemoCardContent(memo: memo)
+
+            MemoCardContent(memo: memo, toggleTaskItem: isAdmin ? { updatedContent in
+                guard let remoteId = memo.remoteId else { return }
+                Task {
+                    try? await onEdit(remoteId, updatedContent, memo.visibility)
+                }
+            } : nil)
         }
         .padding([.top, .bottom], 5)
+        .sheet(isPresented: $isEditingMemo) {
+            ExploreEditMemoSheet(memo: memo, onSave: onEdit)
+        }
+    }
+}
+
+private struct ExploreEditMemoSheet: View {
+    let memo: Memo
+    let onSave: (_ remoteId: String, _ content: String, _ visibility: MemoVisibility) async throws -> Void
+
+    @State private var text: String
+    @State private var visibility: MemoVisibility
+    @State private var saveError: Error?
+    @State private var showingErrorAlert = false
+    @Environment(\.dismiss) private var dismiss
+
+    init(memo: Memo, onSave: @escaping (_ remoteId: String, _ content: String, _ visibility: MemoVisibility) async throws -> Void) {
+        self.memo = memo
+        self.onSave = onSave
+        _text = State(initialValue: memo.content)
+        _visibility = State(initialValue: memo.visibility)
+    }
+
+    var body: some View {
+        NavigationStack {
+            VStack(alignment: .leading) {
+                visibilityPicker
+                    .padding(.horizontal)
+                TextEditor(text: $text)
+                    .padding(.horizontal)
+            }
+            .navigationTitle("input.edit")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .navigationBarLeading) {
+                    Button("input.close") { dismiss() }
+                }
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Button {
+                        Task {
+                            do {
+                                if let remoteId = memo.remoteId {
+                                    try await onSave(remoteId, text, visibility)
+                                }
+                                dismiss()
+                            } catch {
+                                saveError = error
+                                showingErrorAlert = true
+                            }
+                        }
+                    } label: {
+                        Label("input.save", systemImage: "paperplane")
+                    }
+                    .disabled(text.isEmpty)
+                }
+            }
+            .alert(NSLocalizedString("sync.failed.title", comment: "Error alert title"), isPresented: $showingErrorAlert) {
+                Button("memo.action.ok", role: .cancel) {}
+            } message: {
+                Text(saveError?.localizedDescription ?? "")
+            }
+        }
+    }
+
+    private var visibilityPicker: some View {
+        Menu {
+            Section("input.visibility") {
+                ForEach([MemoVisibility.public, .local, .private], id: \.self) { v in
+                    Button {
+                        visibility = v
+                    } label: {
+                        Label(v.title, systemImage: v.iconName)
+                    }
+                }
+            }
+        } label: {
+            HStack {
+                Label(visibility.title, systemImage: visibility.iconName)
+                Image(systemName: "chevron.down")
+            }
+            .font(.footnote)
+            .padding(4)
+            .overlay(
+                RoundedRectangle(cornerRadius: 8)
+                    .stroke(.green, lineWidth: 1)
+            )
+        }
     }
 }

--- a/Packages/Models/Sources/Models/User.swift
+++ b/Packages/Models/Sources/Models/User.swift
@@ -46,6 +46,7 @@ public struct UserSnapshot: Equatable, Sendable {
     public var creationDate: Date
     public var email: String?
     public var remoteId: String?
+    public var isAdmin: Bool
 
     public init(
         accountKey: String,
@@ -54,7 +55,8 @@ public struct UserSnapshot: Equatable, Sendable {
         defaultVisibility: MemoVisibility = .private,
         creationDate: Date = .now,
         email: String? = nil,
-        remoteId: String? = nil
+        remoteId: String? = nil,
+        isAdmin: Bool = false
     ) {
         self.accountKey = accountKey
         self.nickname = nickname
@@ -63,6 +65,7 @@ public struct UserSnapshot: Equatable, Sendable {
         self.creationDate = creationDate
         self.email = email
         self.remoteId = remoteId
+        self.isAdmin = isAdmin
     }
 
     public init(user: User) {
@@ -73,7 +76,8 @@ public struct UserSnapshot: Equatable, Sendable {
             defaultVisibility: user.defaultVisibility,
             creationDate: user.creationDate,
             email: user.email,
-            remoteId: user.remoteId
+            remoteId: user.remoteId,
+            isAdmin: user.isAdmin
         )
     }
 
@@ -92,7 +96,8 @@ public struct UserSnapshot: Equatable, Sendable {
             defaultVisibility: defaultVisibility,
             creationDate: creationDate,
             email: email,
-            remoteId: remoteId
+            remoteId: remoteId,
+            isAdmin: isAdmin
         )
     }
 
@@ -104,6 +109,7 @@ public struct UserSnapshot: Equatable, Sendable {
         user.creationDate = creationDate
         user.email = email
         user.remoteId = remoteId
+        user.isAdmin = isAdmin
     }
 }
 
@@ -118,8 +124,9 @@ public final class User: UserData {
     public var creationDate: Date
     public var email: String?
     public var remoteId: String?
-    
-    public init(accountKey: String, nickname: String, avatarData: Data? = nil, defaultVisibility: MemoVisibility = .private, creationDate: Date = .now, email: String? = nil, remoteId: String? = nil) {
+    public var isAdmin: Bool
+
+    public init(accountKey: String, nickname: String, avatarData: Data? = nil, defaultVisibility: MemoVisibility = .private, creationDate: Date = .now, email: String? = nil, remoteId: String? = nil, isAdmin: Bool = false) {
         self.accountKey = accountKey
         self.nickname = nickname
         self.avatarData = avatarData
@@ -127,6 +134,7 @@ public final class User: UserData {
         self.creationDate = creationDate
         self.email = email
         self.remoteId = remoteId
+        self.isAdmin = isAdmin
     }
     
     public var avatar: UserAvatar? { avatarData.map { .data($0) } }

--- a/Packages/Services/Sources/MemosV0Service/MemosV0Service.swift
+++ b/Packages/Services/Sources/MemosV0Service/MemosV0Service.swift
@@ -233,6 +233,7 @@ public final class MemosV0Service: RemoteService {
             }
             snapshot.avatarData = try? await downloadData(url: url)
         }
+        snapshot.isAdmin = memosUser.role == .HOST || memosUser.role == .ADMIN
         return snapshot
     }
 }

--- a/Packages/Services/Sources/MemosV1Service/MemosV1Service.swift
+++ b/Packages/Services/Sources/MemosV1Service/MemosV1Service.swift
@@ -282,6 +282,7 @@ public final class MemosV1Service: RemoteService {
         if let visibilityString = setting?.generalSetting?.memoVisibility, let visibility = MemosV1Visibility(rawValue: visibilityString) {
             snapshot.defaultVisibility = visibility.toMemoVisibility()
         }
+        snapshot.isAdmin = memosUser.role == .ADMIN
         return snapshot
     }
 }


### PR DESCRIPTION
## Summary

   - Adds an `isAdmin` field to `User`, populated from the server role in both V0 and V1 APIs
   - Shows an edit menu on `ExploreMemoCard` when the current user is an admin viewing another admin's memo on the explore page
   - Calls the remote service directly to save edits, matching the web UI behavior
   - I have tested building this and running it on my local iPhone successfully with my own local memos server.

   ## Motivation

   The memos server already allows admins to edit each other's shared/workspace memos (added in 2024). The web UI exposes this, but MoeMemos did not show any edit UI for these cases. A key use case is families, couples, or close friends who are both admins and want to collaboratively edit shared notes (e.g. a grocery list). I opened #351 for this issue and thought I would take a stab at using claude to try and implement.

   ## Behavior

   - Non-admin users: no change, UI is identical
   - Admin users viewing another admin's memo on the explore page: an ellipsis menu appears with an Edit option