### PR TITLE
Add document scanner attachment flow

### DIFF
--- a/Packages/MemoKit/Sources/MemoKit/Editor/Components/DocumentScanner.swift
+++ b/Packages/MemoKit/Sources/MemoKit/Editor/Components/DocumentScanner.swift
@@ -1,0 +1,60 @@
+import SwiftUI
+import UIKit
+
+#if canImport(VisionKit) && os(iOS) && !targetEnvironment(macCatalyst)
+@preconcurrency import VisionKit
+
+struct DocumentScanner: UIViewControllerRepresentable {
+    enum Result {
+        case success([UIImage])
+        case cancelled
+        case failure(Swift.Error)
+    }
+
+    let onComplete: (Result) -> Void
+
+    static var isSupported: Bool {
+        VNDocumentCameraViewController.isSupported
+    }
+
+    func makeUIViewController(context: Context) -> VNDocumentCameraViewController {
+        let controller = VNDocumentCameraViewController()
+        controller.delegate = context.coordinator
+        return controller
+    }
+
+    func updateUIViewController(_ uiViewController: VNDocumentCameraViewController, context: Context) {
+    }
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(parent: self)
+    }
+
+    final class Coordinator: NSObject, VNDocumentCameraViewControllerDelegate {
+        private let parent: DocumentScanner
+
+        init(parent: DocumentScanner) {
+            self.parent = parent
+        }
+
+        func documentCameraViewController(_ controller: VNDocumentCameraViewController, didFinishWith scan: VNDocumentCameraScan) {
+            let images = (0..<scan.pageCount).map { scan.imageOfPage(at: $0) }
+            controller.dismiss(animated: true) { [parent] in
+                parent.onComplete(.success(images))
+            }
+        }
+
+        func documentCameraViewControllerDidCancel(_ controller: VNDocumentCameraViewController) {
+            controller.dismiss(animated: true) { [parent] in
+                parent.onComplete(.cancelled)
+            }
+        }
+
+        func documentCameraViewController(_ controller: VNDocumentCameraViewController, didFailWithError error: Swift.Error) {
+            controller.dismiss(animated: true) { [parent] in
+                parent.onComplete(.failure(error))
+            }
+        }
+    }
+}
+#endif

--- a/Packages/MemoKit/Sources/MemoKit/Editor/Components/MemoEditorToolbar.swift
+++ b/Packages/MemoKit/Sources/MemoKit/Editor/Components/MemoEditorToolbar.swift
@@ -9,6 +9,8 @@ struct MemoEditorToolbar: View {
     let supportsJournalingSuggestions: Bool
     let onPickPhotos: () -> Void
     let onPickCamera: () -> Void
+    let supportsDocumentScanning: Bool
+    let onScanDocument: () -> Void
     let onPickFiles: () -> Void
     
     @ViewBuilder
@@ -56,6 +58,14 @@ struct MemoEditorToolbar: View {
                 onPickCamera()
             } label: {
                 Image(systemName: "camera")
+            }
+
+            if supportsDocumentScanning {
+                Button {
+                    onScanDocument()
+                } label: {
+                    Image(systemName: "doc.viewfinder")
+                }
             }
 
             Button {

--- a/Packages/MemoKit/Sources/MemoKit/Editor/MemoEditor.swift
+++ b/Packages/MemoKit/Sources/MemoKit/Editor/MemoEditor.swift
@@ -29,6 +29,7 @@ public struct MemoEditor: View {
 
     @State private var showingPhotoPicker = false
     @State private var showingImagePicker = false
+    @State private var showingDocumentScanner = false
     @State private var showingFilePicker = false
     @State private var showingJournalingSuggestionsPicker = false
     @State private var submitError: Error?
@@ -76,6 +77,10 @@ public struct MemoEditor: View {
             },
             onPickCamera: {
                 showingImagePicker = true
+            },
+            supportsDocumentScanning: supportsDocumentScanning,
+            onScanDocument: {
+                showingDocumentScanner = true
             },
             onPickFiles: {
                 showingFilePicker = true
@@ -174,6 +179,16 @@ public struct MemoEditor: View {
             }
             .edgesIgnoringSafeArea(.all)
         })
+#if canImport(VisionKit) && os(iOS) && !targetEnvironment(macCatalyst)
+        .fullScreenCover(isPresented: $showingDocumentScanner) {
+            DocumentScanner { result in
+                Task {
+                    await handleDocumentScan(result)
+                }
+            }
+            .edgesIgnoringSafeArea(.all)
+        }
+#endif
         .interactiveDismissDisabled()
     }
 
@@ -250,6 +265,44 @@ public struct MemoEditor: View {
             submitError = error
             showingErrorToast = true
         }
+    }
+
+#if canImport(VisionKit) && os(iOS) && !targetEnvironment(macCatalyst)
+    private func handleDocumentScan(_ result: DocumentScanner.Result) async {
+        showingDocumentScanner = false
+
+        switch result {
+        case .success(let images):
+            do {
+                let data = try ScannedDocumentPDFBuilder.makePDFData(from: images)
+                try await viewModel.upload(data: data, filename: scannedDocumentFilename(), mimeType: "application/pdf")
+                submitError = nil
+            } catch {
+                submitError = error
+                showingErrorToast = true
+            }
+        case .cancelled:
+            break
+        case .failure(let error):
+            submitError = error
+            showingErrorToast = true
+        }
+    }
+#endif
+
+    private var supportsDocumentScanning: Bool {
+#if canImport(VisionKit) && os(iOS) && !targetEnvironment(macCatalyst)
+        DocumentScanner.isSupported
+#else
+        false
+#endif
+    }
+
+    private func scannedDocumentFilename(date: Date = Date()) -> String {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.dateFormat = "yyyyMMdd-HHmmss"
+        return "scan-\(formatter.string(from: date)).pdf"
     }
 
     private func saveMemo() async throws {

--- a/Packages/MemoKit/Sources/MemoKit/Editor/ScannedDocumentPDFBuilder.swift
+++ b/Packages/MemoKit/Sources/MemoKit/Editor/ScannedDocumentPDFBuilder.swift
@@ -1,0 +1,29 @@
+import UIKit
+
+public enum ScannedDocumentPDFBuilder {
+    public enum Error: LocalizedError, Equatable {
+        case emptyDocument
+
+        public var errorDescription: String? {
+            switch self {
+            case .emptyDocument:
+                "Scanned document contains no pages."
+            }
+        }
+    }
+
+    public static func makePDFData(from images: [UIImage]) throws -> Data {
+        guard !images.isEmpty else {
+            throw Error.emptyDocument
+        }
+
+        let renderer = UIGraphicsPDFRenderer(bounds: CGRect(origin: .zero, size: images[0].size))
+        return renderer.pdfData { context in
+            for image in images {
+                let pageBounds = CGRect(origin: .zero, size: image.size)
+                context.beginPage(withBounds: pageBounds, pageInfo: [:])
+                image.draw(in: pageBounds)
+            }
+        }
+    }
+}

--- a/Packages/MemoKit/Tests/MemoKitTests/MemoKitTests.swift
+++ b/Packages/MemoKit/Tests/MemoKitTests/MemoKitTests.swift
@@ -1,8 +1,31 @@
 import XCTest
+import UIKit
 @testable import MemoKit
 
 final class MemoKitTests: XCTestCase {
-    func testPlaceholder() {
-        XCTAssertTrue(true)
+    func testScannedDocumentPDFBuilderCreatesPDFData() throws {
+        let images = [
+            makeImage(size: CGSize(width: 100, height: 160), color: .red),
+            makeImage(size: CGSize(width: 120, height: 80), color: .blue)
+        ]
+
+        let data = try ScannedDocumentPDFBuilder.makePDFData(from: images)
+
+        XCTAssertFalse(data.isEmpty)
+        XCTAssertEqual(String(data: data.prefix(4), encoding: .ascii), "%PDF")
+    }
+
+    func testScannedDocumentPDFBuilderRejectsEmptyInput() {
+        XCTAssertThrowsError(try ScannedDocumentPDFBuilder.makePDFData(from: [])) { error in
+            XCTAssertEqual(error as? ScannedDocumentPDFBuilder.Error, .emptyDocument)
+        }
+    }
+
+    private func makeImage(size: CGSize, color: UIColor) -> UIImage {
+        let renderer = UIGraphicsImageRenderer(size: size)
+        return renderer.image { context in
+            color.setFill()
+            context.fill(CGRect(origin: .zero, size: size))
+        }
     }
 }


### PR DESCRIPTION
## Summary

Adds a native iOS document scanning flow to the memo editor so scanned paper documents can be attached as a single PDF file.

The new scan button sits between the existing camera and file attachment buttons. It uses `VNDocumentCameraViewController`, converts the scanned pages into one PDF, and then reuses the existing resource upload path.

This is intended for scanned documents where a PDF attachment is more appropriate and usually smaller than uploading multiple full-size image attachments.

## Changes

- Add a VisionKit-backed document scanner wrapper.
- Add a PDF builder for scanned page images.
- Add a document scan button to the memo editor toolbar.
- Upload completed scans as `application/pdf` resources.
- Add focused tests for PDF generation.

## Testing

- Built successfully with:
  `xcodebuild -skipPackagePluginValidation -project MoeMemos.xcodeproj -scheme MoeMemos -destination 'generic/platform=iOS' CODE_SIGNING_ALLOWED=NO build`
- Built and launched successfully in iOS Simulator.

I have not tested the scanner flow on a physical device because I do not currently have a paid Apple Developer certificate/profile for the app capabilities. The simulator can launch the app, but the actual document scanner is expected to require a real device camera.
