### PR TITLE
feat: add Home Screen Quick Action to create a new memo

### DIFF
--- a/MoeMemos/Info.plist
+++ b/MoeMemos/Info.plist
@@ -33,5 +33,16 @@
 		<string>MemoryWidgetConfigurationIntent</string>
 		<string>MemosGraphWidgetConfigurationIntent</string>
 	</array>
+	<key>UIApplicationShortcutItems</key>
+	<array>
+		<dict>
+			<key>UIApplicationShortcutItemIconType</key>
+			<string>UIApplicationShortcutIconTypeCompose</string>
+			<key>UIApplicationShortcutItemTitle</key>
+			<string>Compose</string>
+			<key>UIApplicationShortcutItemType</key>
+			<string>me.mudkip.MoeMemos.new-memo</string>
+		</dict>
+	</array>
 </dict>
 </plist>

--- a/MoeMemos/MoeMemosApp.swift
+++ b/MoeMemos/MoeMemosApp.swift
@@ -12,10 +12,69 @@ import Factory
 import AppIntents
 import Env
 import SwiftData
+import UIKit
+
+private enum AppShortcutAction {
+    static let newMemoSuffix = ".new-memo"
+
+    static var newMemoType: String {
+        "\(Bundle.main.bundleIdentifier ?? "me.mudkip.MoeMemos")\(newMemoSuffix)"
+    }
+
+    static func configureShortcutItems() {
+        UIApplication.shared.shortcutItems = [
+            UIApplicationShortcutItem(
+                type: newMemoType,
+                localizedTitle: NSLocalizedString("input.compose", comment: "Compose"),
+                localizedSubtitle: nil,
+                icon: UIApplicationShortcutIcon(type: .compose),
+                userInfo: nil
+            )
+        ]
+    }
+
+    static func handle(_ shortcutItem: UIApplicationShortcutItem) -> Bool {
+        guard shortcutItem.type.hasSuffix(newMemoSuffix) else {
+            return false
+        }
+
+        Task { @MainActor in
+            Container.shared.appPath().presentedSheet = .newMemo
+        }
+        return true
+    }
+}
+
+final class AppDelegate: NSObject, UIApplicationDelegate {
+    func application(
+        _ application: UIApplication,
+        didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
+    ) -> Bool {
+        AppShortcutAction.configureShortcutItems()
+
+        guard
+            let shortcutItem = launchOptions?[.shortcutItem] as? UIApplicationShortcutItem,
+            AppShortcutAction.handle(shortcutItem)
+        else {
+            return true
+        }
+
+        return false
+    }
+
+    func application(
+        _ application: UIApplication,
+        performActionFor shortcutItem: UIApplicationShortcutItem,
+        completionHandler: @escaping (Bool) -> Void
+    ) {
+        completionHandler(AppShortcutAction.handle(shortcutItem))
+    }
+}
 
 @main
 @MainActor
 struct MoeMemosApp: App {
+    @UIApplicationDelegateAdaptor(AppDelegate.self) private var appDelegate
     @Injected(\.appInfo) private var appInfo
     @Injected(\.accountViewModel) private var userState
     @Injected(\.accountManager) private var accountManager


### PR DESCRIPTION
## Summary

- Registers a `UIApplicationShortcutItem` so long-pressing the app icon shows a **Compose** quick action
- Handles both cold launch (via `didFinishLaunchingWithOptions`) and warm launch (via `performActionFor shortcutItem`)
- Title is localized using the existing `input.compose` key, covering all supported languages

## Test plan

- [ ] Long-press the app icon on the Home Screen — "Compose" action appears
- [ ] Tap the action while the app is in the background — new memo editor opens
- [ ] Force-quit the app, then long-press and tap the action — new memo editor opens on launch
- [ ] Verify localized title displays correctly on a non-English device